### PR TITLE
Corrected MSSL CCD test results

### DIFF
--- a/euvst_response/config.py
+++ b/euvst_response/config.py
@@ -139,7 +139,7 @@ class Detector_SWC:
     read_noise_rms: u.Quantity = 10.0 * u.electron / u.pixel
     dark_current: u.Quantity = 21.0 * u.electron / (u.pixel * u.s)  # Default value, will be overridden
     _dark_current_293k: u.Quantity = 20000.0 * u.electron / (u.pixel * u.s)  # Q_d0 at 293 K
-    gain_e_per_dn: u.Quantity = 2.0 * u.electron / u.DN
+    gain_e_per_dn: u.Quantity = 2.78 * u.electron / u.DN  # MSSL EM test results
     max_dn: u.Quantity = 65535 * u.DN / u.pixel
     pix_size: u.Quantity = (13.5 * u.um).cgs / u.pixel
     wvl_res: u.Quantity = (16.9 * u.mAA).cgs / u.pixel


### PR DESCRIPTION
This pull request updates detector configuration parameters in the `Detector_SWC` class to reflect more recent or accurate test results.

Detector parameter updates:

* Increased `_dark_current_293k` from `10000.0` to `20000.0` electrons per (pixel * second), updating the dark current reference value at 293 K.
* Updated `gain_e_per_dn` from `2.0` to `2.78` electrons per DN, based on MSSL EM test results.