### PR TITLE
implement per-source inverse-transform kwargs

### DIFF
--- a/euvst_response/monte_carlo.py
+++ b/euvst_response/monte_carlo.py
@@ -18,7 +18,16 @@ from .fitting import fit_cube_gauss
 from .utils import angle_to_distance, rebin_slit_offchip, _get_mpi_info
 
 
-def simulate_once(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim) -> Tuple[NDCube, ...]:
+def simulate_once(
+    I_cube: NDCube,
+    t_exp: u.Quantity,
+    det,
+    tel,
+    sim,
+    *,
+    photon_shot_inverse_transform: bool = False,
+    dark_current_inverse_transform: bool = False,
+) -> Tuple[NDCube, ...]:
     """
     Run a single Monte Carlo simulation of the instrument response.
     
@@ -34,6 +43,12 @@ def simulate_once(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim) -> Tuple[NDC
         Telescope configuration
     sim : Simulation
         Simulation configuration
+    photon_shot_inverse_transform : bool, optional
+        Use inverse-transform Poisson sampling for photon shot noise.
+        Enables CRN across runs that differ only in photon flux.  Default False.
+    dark_current_inverse_transform : bool, optional
+        Use inverse-transform Poisson sampling for dark-current shot noise.
+        Enables CRN across runs that differ only in dark-current level.  Default False.
         
     Returns
     -------
@@ -68,10 +83,16 @@ def simulate_once(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim) -> Tuple[NDC
         photons_euv_pinholes = photons_focused
 
     # Sample discrete photon arrivals (photon shot noise)
-    photon_arrivals = sample_photon_arrivals(photons_euv_pinholes)
+    photon_arrivals = sample_photon_arrivals(
+        photons_euv_pinholes,
+        photon_shot_inverse_transform=photon_shot_inverse_transform,
+    )
 
     # Convert to electrons (detector response: QE, Fano noise, dark current, read noise)
-    electrons = to_electrons(photon_arrivals, t_exp, det)
+    electrons = to_electrons(
+        photon_arrivals, t_exp, det,
+        dark_current_inverse_transform=dark_current_inverse_transform,
+    )
     
     # Add visible stray light (with filter throughput)
     electrons_stray = add_visible_stray_light(electrons, t_exp, det, sim, tel)
@@ -92,7 +113,9 @@ def simulate_once(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim) -> Tuple[NDC
 
 def monte_carlo(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim, n_iter: int = 5,
                 fit_config=None, offchip_bin_slit: int = 1,
-                fit_signals: str = "both", uniform_mode: bool = False) -> Tuple[NDCube, dict | None, NDCube, dict | None]:
+                fit_signals: str = "both", uniform_mode: bool = False,
+                photon_shot_inverse_transform: bool = False,
+                dark_current_inverse_transform: bool = False) -> Tuple[NDCube, dict | None, NDCube, dict | None]:
     """
     Run Monte Carlo simulations and fit results.
     
@@ -126,6 +149,12 @@ def monte_carlo(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim, n_iter: int = 
         the resulting spectra are stacked so that fitting is parallelised
         over the n_iter iterations rather than over the spatial dimension.
         Default: False.
+    photon_shot_inverse_transform : bool, optional
+        Use inverse-transform Poisson sampling for photon shot noise.
+        Enables CRN across runs that differ only in photon flux.  Default False.
+    dark_current_inverse_transform : bool, optional
+        Use inverse-transform Poisson sampling for dark-current shot noise.
+        Enables CRN across runs that differ only in dark-current level.  Default False.
         
     Returns
     -------
@@ -165,7 +194,11 @@ def monte_carlo(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim, n_iter: int = 
                       disable=not show_progress):
             (intensity_exp, photons_total, photons_throughput, photons_pixels,
              photons_focused, photon_arrivals, electrons, electrons_stray,
-             electrons_pinholes, dn) = simulate_once(I_cube, t_exp, det, tel, sim)
+             electrons_pinholes, dn) = simulate_once(
+                I_cube, t_exp, det, tel, sim,
+                photon_shot_inverse_transform=photon_shot_inverse_transform,
+                dark_current_inverse_transform=dark_current_inverse_transform,
+            )
 
             if i == 0 and rank == 0:
                 first_dn_signal = rebin_slit_offchip(dn, offchip_bin_slit)
@@ -244,7 +277,11 @@ def monte_carlo(I_cube: NDCube, t_exp: u.Quantity, det, tel, sim, n_iter: int = 
             # Simulate one run
             (intensity_exp, photons_total, photons_throughput, photons_pixels,
              photons_focused, photon_arrivals, electrons, electrons_stray,
-             electrons_pinholes, dn) = simulate_once(I_cube, t_exp, det, tel, sim)
+             electrons_pinholes, dn) = simulate_once(
+                I_cube, t_exp, det, tel, sim,
+                photon_shot_inverse_transform=photon_shot_inverse_transform,
+                dark_current_inverse_transform=dark_current_inverse_transform,
+            )
 
             # Store first iteration signals only on rank 0 (binned, to match fit shapes)
             if i == 0 and rank == 0:

--- a/euvst_response/radiometric.py
+++ b/euvst_response/radiometric.py
@@ -11,6 +11,8 @@ from scipy.signal import convolve2d
 from .utils import wl_to_vel, vel_to_wl, debug_break
 
 
+
+
 def _vectorized_fano_noise(photon_counts: np.ndarray, rest_wavelength: u.Quantity, det) -> np.ndarray:
     """
     Vectorized version of Fano noise calculation for improved performance.
@@ -213,7 +215,13 @@ def apply_focusing_optics_psf(signal: NDCube, tel) -> NDCube:
     )
 
 
-def to_electrons(photon_counts: NDCube, t_exp: u.Quantity, det) -> NDCube:
+def to_electrons(
+    photon_counts: NDCube,
+    t_exp: u.Quantity,
+    det,
+    *,
+    dark_current_inverse_transform: bool = False,
+) -> NDCube:
     """
     Convert a photon-count NDCube to an electron-count NDCube.
 
@@ -225,6 +233,15 @@ def to_electrons(photon_counts: NDCube, t_exp: u.Quantity, det) -> NDCube:
         Exposure time (used for dark current and read noise).
     det : Detector_SWC or Detector_EIS
         Detector description.
+    dark_current_inverse_transform : bool, optional
+        When True, dark-current shot noise is drawn by inverse-transform
+        (quantile) sampling: one uniform draw per pixel passed through the
+        Poisson inverse-CDF (scipy.stats.poisson.ppf).  The marginal
+        distribution is identical to np.random.poisson, but unlike rejection
+        sampling this consumes a fixed number of RNG draws per pixel, keeping
+        the random stream synchronised across runs that differ only in
+        dark-current level.  This enables common-random-number variance
+        reduction.  Default False.
 
     Returns
     -------
@@ -242,10 +259,20 @@ def to_electrons(photon_counts: NDCube, t_exp: u.Quantity, det) -> NDCube:
 
     e = electron_counts * (u.electron / u.pixel)
 
-    # Add dark current with Poisson noise (per pixel)
+    # Add dark current with Poisson shot noise (per pixel)
     dark_current_mean = (det.dark_current * t_exp).to(u.electron / u.pixel).value
-    dark_current_poisson = np.random.poisson(dark_current_mean, size=photon_counts.data.shape) * (u.electron / u.pixel)
-    e += dark_current_poisson
+    if dark_current_inverse_transform:
+        # Inverse-transform Poisson: one uniform per pixel through the Poisson
+        # inverse-CDF.  Same marginal as np.random.poisson but consumes a
+        # fixed number of RNG draws (CRN-friendly).
+        from scipy.stats import poisson as _poisson
+        u_dark = np.random.random(size=photon_counts.data.shape)
+        dark_current_counts = _poisson.ppf(u_dark, dark_current_mean)
+    else:
+        # Standard Poisson (rejection sampling, variable RNG use).
+        dark_current_counts = np.random.poisson(dark_current_mean, size=photon_counts.data.shape)
+    dark_current_signal = dark_current_counts * (u.electron / u.pixel)
+    e += dark_current_signal
     
     # Add read noise
     e += np.random.normal(0, det.read_noise_rms.value,
@@ -317,7 +344,11 @@ def add_poisson(cube: NDCube) -> NDCube:
     )
 
 
-def sample_photon_arrivals(photon_counts: NDCube) -> NDCube:
+def sample_photon_arrivals(
+    photon_counts: NDCube,
+    *,
+    photon_shot_inverse_transform: bool = False,
+) -> NDCube:
     """
     Sample a discrete Poisson realisation of photon arrivals per pixel.
 
@@ -331,6 +362,14 @@ def sample_photon_arrivals(photon_counts: NDCube) -> NDCube:
     ----------
     photon_counts : NDCube
         Expected (mean) photon counts per pixel.
+    photon_shot_inverse_transform : bool, optional
+        When True, photon shot noise is drawn by inverse-transform (quantile)
+        sampling: one uniform draw per pixel passed through the Poisson
+        inverse-CDF (scipy.stats.poisson.ppf).  The marginal distribution is
+        identical to np.random.poisson, but unlike rejection sampling this
+        consumes a fixed number of RNG draws per pixel, keeping the random
+        stream synchronised across runs that differ only in photon flux.
+        This enables common-random-number variance reduction.  Default False.
 
     Returns
     -------
@@ -344,7 +383,12 @@ def sample_photon_arrivals(photon_counts: NDCube) -> NDCube:
     mean_counts = q.to(canonical_units).value
     mean_counts = np.maximum(mean_counts, 0)
 
-    sampled = np.random.poisson(mean_counts)
+    if photon_shot_inverse_transform:
+        from scipy.stats import poisson as _poisson
+        u_shot = np.random.random(size=mean_counts.shape)
+        sampled = _poisson.ppf(u_shot, mean_counts)
+    else:
+        sampled = np.random.poisson(mean_counts)
 
     return NDCube(
         data=sampled.astype(np.int64),


### PR DESCRIPTION
- Add dark_current_inverse_transform kwarg to to_electrons()
- Add photon_shot_inverse_transform kwarg to sample_photon_arrivals()
- Thread both kwargs through simulate_once() and monte_carlo()
- Callers opt in explicitly at the monte_carlo() call site instead of mutating global state; this makes the choice visible, reentrant, and testable